### PR TITLE
Fix grid view selector

### DIFF
--- a/snippets/product-grid.liquid
+++ b/snippets/product-grid.liquid
@@ -146,12 +146,12 @@
     (() => {
       const grid = document.querySelector('.product-grid');
 
-      if (grid) {
-        const currentDevice = window.innerWidth >= 750 ? 'desktop' : 'mobile';
-        const storedLayout = sessionStorage.getItem(`product-grid-view-${currentDevice}`);
+      ['desktop', 'mobile'].forEach((viewport) => {
+        const storedLayout = sessionStorage.getItem(`product-grid-view-${viewport}`);
 
         if (storedLayout) {
-          const options = document.querySelectorAll(`input[type="radio"][name="grid"]`);
+          const options = document
+            .querySelectorAll(`input[type="radio"][name="grid${viewport === 'mobile' ? '-mobile' : ''}"]`);
 
           grid.setAttribute('product-grid-view', storedLayout);
 
@@ -159,7 +159,7 @@
             option.checked = option.value === storedLayout;
           }
         }
-      }
+      });
     })();
   </script>
 {% endunless %}


### PR DESCRIPTION
Fixes the grid view selector for desktop and mobile. Currently only the desktop selector gets set.

**Steps to reproduce:** 
1. Open mobile view of collection page: https://theme-horizon-demo.myshopify.com/collections/mens-pants
2. Switch to "single product" view
3. Refresh page
-> Grid column switcher shows the wrong state