### PR TITLE
Fix section rendering using default theme ID

### DIFF
--- a/assets/section-renderer.js
+++ b/assets/section-renderer.js
@@ -83,7 +83,7 @@ class SectionRenderer {
       if (cachedHTML) return cachedHTML;
     }
 
-    pendingPromise = fetch(sectionUrl).then((response) => {
+    pendingPromise = fetch(sectionUrl, { credentials: 'include' }).then((response) => {
       return response.text();
     });
 


### PR DESCRIPTION
Fix section rendering sometimes fetching HTML from the wrong Theme ID (when using `preview_theme_id` in a cookie) and multiple markets on different domains