### PR TITLE
Use hide-when-empty as a class, so CSS will work correctly

### DIFF
--- a/snippets/list-filter.liquid
+++ b/snippets/list-filter.liquid
@@ -76,16 +76,17 @@
             data-filter-style="{{ filter_style }}"
           >
             <span
+              class="
               {% if filter_style == 'horizontal' %}
                 {% if active_value_count > 1 %}
-                  class="bubble facets__bubble"
+                  bubble facets__bubble
                 {% endif %}
               {% else %}
                 {% if active_value_count > 0 %}
-                  class="bubble facets__bubble"
+                  bubble facets__bubble
                 {% endif %}
               {% endif %}
-              hide-when-empty
+              hide-when-empty"
               ref="facetStatus"
             >
               {%- liquid


### PR DESCRIPTION
`horizon/assets/base.css:488` lists 
```
.hide-when-empty:empty {
  /* stylelint-disable-next-line declaration-no-important */
  display: none !important;
}
```

which will not work for the `<span>` which uses `hide-when-empty` as an attribute instead of a class.