### PR TITLE
Allow app blocks between article sections

### DIFF
--- a/blocks/_blog-post-featured-image.liquid
+++ b/blocks/_blog-post-featured-image.liquid
@@ -7,39 +7,41 @@
   assign image = closest.article.image
 %}
 
-<div
-  class="blog-post-featured-image blog-post-featured-image--{{ block.id }} blog-post-featured-image--height-{{ block_settings.height }} spacing-style size-style"
-  style="
-    --ratio: {% case block_settings.image_ratio %}
-      {% when 'landscape' %}16 / 9
-      {% when 'portrait' %}4 / 5
-      {% when 'adapt' %}{{ image.aspect_ratio | default: 1 }}
-      {% else %}1
-    {% endcase %};
-    {% render 'size-style', settings: block_settings %}
-    {% render 'spacing-style', settings: block_settings %}
-  "
-  {{ block.shopify_attributes }}
->
-  {%- capture image_border_style -%}
-    {% render 'border-override', settings: block_settings %}
-  {%- endcapture -%}
+{% if image != blank %}
+  <div
+    class="blog-post-featured-image blog-post-featured-image--{{ block.id }} blog-post-featured-image--height-{{ block_settings.height }} spacing-style size-style"
+    style="
+      --ratio: {% case block_settings.image_ratio %}
+        {% when 'landscape' %}16 / 9
+        {% when 'portrait' %}4 / 5
+        {% when 'adapt' %}{{ image.aspect_ratio | default: 1 }}
+        {% else %}1
+      {% endcase %};
+      {% render 'size-style', settings: block_settings %}
+      {% render 'spacing-style', settings: block_settings %}
+    "
+    {{ block.shopify_attributes }}
+  >
+    {%- capture image_border_style -%}
+      {% render 'border-override', settings: block_settings %}
+    {%- endcapture -%}
 
-  {{
-    image
-    | image_url: width: 3840
-    | image_tag:
-      width: image.width,
-      widths: '240, 352, 832, 1200, 1600, 1920, 2560, 3840',
-      height: image.height,
-      class: 'blog-post-featured-image__image border-style',
-      style: image_border_style,
-      sizes: 'auto, (min-width: 750px) 100vw, 100vw',
-      loading: 'eager',
-      fetchpriority: 'high',
-      alt: image.alt
-  }}
-</div>
+    {{
+      image
+      | image_url: width: 3840
+      | image_tag:
+        width: image.width,
+        widths: '240, 352, 832, 1200, 1600, 1920, 2560, 3840',
+        height: image.height,
+        class: 'blog-post-featured-image__image border-style',
+        style: image_border_style,
+        sizes: 'auto, (min-width: 750px) 100vw, 100vw',
+        loading: 'eager',
+        fetchpriority: 'high',
+        alt: image.alt
+    }}
+  </div>
+{% endif %}
 
 {% stylesheet %}
   .blog-post-featured-image {

--- a/sections/main-blog-post.liquid
+++ b/sections/main-blog-post.liquid
@@ -13,17 +13,6 @@
       {% render 'spacing-style', settings: section.settings %}
     "
   >
-    <header>
-      {%- content_for 'block', id: 'blog-post-title', type: 'text' %}
-      {%- content_for 'block', id: 'blog-post-details', type: '_blog-post-info-text' %}
-    </header>
-
-    {%- if article.image -%}
-      {%- content_for 'block', id: 'blog-post-image', type: '_blog-post-featured-image' %}
-    {%- endif -%}
-    {%- content_for 'block', id: 'blog-post-content', type: '_blog-post-content' %}
-
-    {% comment %} Dynamic area for @app blocks only, at the bottom {% endcomment %}
     {% content_for 'blocks' %}
 
     {% if blog.comments_enabled? %}
@@ -119,6 +108,15 @@
     },
     {
       "type": "@app"
+    },
+    {
+      "type": "_blog-post-info-text"
+    },
+    {
+      "type": "_blog-post-featured-image"
+    },
+    {
+      "type": "_blog-post-content"
     }
   ],
   "class": "section-wrapper",

--- a/templates/article.json
+++ b/templates/article.json
@@ -15,7 +15,6 @@
         "blog-post-title": {
           "type": "text",
           "name": "Title",
-          "static": true,
           "settings": {
             "text": "<h1>{{ article.title }}</h1>",
             "width": "100%",
@@ -42,7 +41,6 @@
         "blog-post-details": {
           "type": "_blog-post-info-text",
           "name": "Details",
-          "static": true,
           "settings": {
             "show_date": true,
             "show_author": false,
@@ -57,7 +55,6 @@
         "blog-post-image": {
           "type": "_blog-post-featured-image",
           "name": "Featured image",
-          "static": true,
           "settings": {
             "image_ratio": "landscape",
             "width": "fill",
@@ -78,11 +75,16 @@
         },
         "blog-post-content": {
           "type": "_blog-post-content",
-          "static": true,
           "settings": {},
           "blocks": {}
         }
       },
+      "block_order": [
+        "blog-post-title",
+        "blog-post-details",
+        "blog-post-image",
+        "blog-post-content"
+      ],
       "settings": {
         "content_direction": "column",
         "gap": 32,


### PR DESCRIPTION
## Problem

App blocks on the article page are forced to render below all article content. Unlike the product page where merchants can place app blocks between sections like title and price, the article page pins its blocks to fixed positions using static `content_for 'block'` calls, with `content_for 'blocks'` only at the bottom.

This is extremely limiting for apps that interact with blog post templates (eg. my app, Recipe Kit). Our team spends hours every week working with merchants to simply place their recipe card in a good looking spot on the Horizon theme - but this fix will resolve that for us and all the other blog post apps.

## Solution

Switch the article section to use `content_for 'blocks'` (the same pattern used by `_product-details`) so all blocks render in the order merchants arrange them in the theme editor.

**Changes:**
- Replace pinned `content_for 'block'` calls with `content_for 'blocks'` in `main-blog-post.liquid`
- Remove `static: true` from article template blocks and add `block_order` to preserve default ordering
- Add `_blog-post-*` types to the section schema (required once blocks are no longer static)
- Move the image nil guard into `_blog-post-featured-image.liquid` since the block is now self-contained