### PR TITLE
Fix: Dispatch change event when updating variant ID input

### DIFF
--- a/assets/product-form.js
+++ b/assets/product-form.js
@@ -645,6 +645,7 @@ class ProductFormComponent extends Component {
 
     const { variantId } = this.refs;
     variantId.value = event.detail.resource?.id ?? '';
+    variantId.dispatchEvent(new Event('change', { bubbles: true }));
 
     this.#variantChangeInProgress = false;
 

--- a/assets/product-form.js
+++ b/assets/product-form.js
@@ -799,6 +799,7 @@ class ProductFormComponent extends Component {
 
       const { variantId } = this.refs;
       variantId.value = resource?.id ?? '';
+      variantId.dispatchEvent(new Event('change', { bubbles: true }));
 
       const { addToCartButtonContainer: currentAddToCartButtonContainer, acceleratedCheckoutButtonContainer } =
         this.refs;


### PR DESCRIPTION
#### Problem

The variant ID is updated programmatically, which does not trigger native `input` or `change` events. Although this input is hidden, it is the required `name="id"` field for the Shopify **Add to Cart** form.

Many Shopify apps use this specific input as their primary source of truth because it is the most reliable way to identify the selected variant across different themes. Because the field remains "silent" during scripted updates, these apps cannot detect variant changes, causing their state or widgets to fall out of sync with the product page.

#### Solution

Manually dispatch a `change` event with `{ bubbles: true }` immediately after the value is updated. This ensures the event propagates up the DOM, allowing both the theme and third-party apps to respond correctly.

---

I am aware the README states that PRs are not currently accepted. I am submitting this as a reference to address a widespread compatibility issue. I hope this can be considered for a future internal update to improve the theme's interoperability.
