### PR TITLE
Refactor: Remove redundant block_settings assignment in _header-menu …

### DIFF
--- a/blocks/_header-menu.liquid
+++ b/blocks/_header-menu.liquid
@@ -52,7 +52,6 @@
     {% endif %}
   {% else %}
     {% liquid
-      assign block_settings = block.settings
       assign menu_content_type = block_settings.menu_style | default: 'text'
       assign image_border_radius = block_settings.image_border_radius
       assign color_scheme_classes = ''


### PR DESCRIPTION
## Summary
Removed a redundant assignment of `block_settings` on line 55 of `header-menu-block.liquid`.

## Why
The variable `block_settings` is already assigned on line 10 at the top of the file.