### PR TITLE
fix: display slideshow arrows only if generic images exist

### DIFF
--- a/snippets/product-media-gallery-content.liquid
+++ b/snippets/product-media-gallery-content.liquid
@@ -73,7 +73,11 @@
     assign slideshow_class = ''
 
     if media_presentation == 'carousel'
-      assign render_slideshow_arrows = true
+      assign pdp_variant_images = selected_product.images | where: 'attached_to_variant?', true | map: 'src'
+      assign pdp_generic_media_size = selected_product.media.size | minus: pdp_variant_images.size
+      if pdp_generic_media_size > 0
+        assign render_slideshow_arrows = true
+      endif
     endif
   endif
 


### PR DESCRIPTION
Context:
If color swatches are enabled and multiple product variants (with their variant image) exist, the current version of Horizon will always display slideshow arrows – even if no "generic" images are present. In this case, clicking the arrow will have no effect, thus confusing the user.

Fix:
Added a check for generic images which are not attached to a variant. Hide slideshow arrows if not the case.