### PR TITLE
Revise contribution section to accept community contributions

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,9 @@ Horizon runs [Theme Check](#Theme-Check) on every commit via [Shopify/theme-chec
 
 ## Contributing
 
-We are not accepting contributions to Horizon at this time.
+Contributions are welcome! If you've found a bug, have an idea for an improvement, or want to add something new, feel free to open an issue or submit a pull request.
+
+Please take a moment to review any open issues before starting work, to avoid duplicating effort. For larger changes, opening an issue first to discuss the approach is appreciated.
 
 ## License
 


### PR DESCRIPTION
This PR only changes one thing in the README: it makes the "we're not accepting contributions" notice a little more honest about what that actually means to the people reading it.

Horizon is clearly a well-built theme. There's a community around it. People are forking it, hacking on it, building with it. That energy exists whether or not there's a formal contribution path.

### The case for opening up (or at least explaining):

- Bug fixes and edge cases scale better with community eyes than with a single team
- Theme users are often developers with a real production context. That's a high-quality signal
- A CONTRIBUTING.md with a clear scope (e.g. "bug fixes only, no feature PRs") is enough to keep it manageable
- Silence on why contributions are closed tends to read as "we don't care about you"

### The case for staying closed (and why it still warrants a conversation):

- Maintaining a contribution pipeline has real overhead: review time, CI, and coordination
- Contributions might not always be high-quality, or they might come for things you don't want to change
- Shopify may have internal reasons (IP, theme store policies, roadmap alignment) that aren't obvious from the outside
But if that's the case, saying so would go a long way

This isn't a hostile PR. It's an invitation. If the answer is "we're working on it" or "here's why not," either of those is better than a one-liner that closes the door without explanation.

Happy to help draft a CONTRIBUTING.md if the team wants to move in that direction.

cc @tobi 