### PR TITLE
Fix duplicate accessibility IDs in repeatable blocks

### DIFF
--- a/blocks/contact-form.liquid
+++ b/blocks/contact-form.liquid
@@ -16,7 +16,14 @@
   "
   {{ block.shopify_attributes }}
 >
-  {% assign form_id = block.id | default: section.id | prepend: 'ContactForm-' %}
+  {% liquid
+    assign form_id = block.id | default: section.id | prepend: 'ContactForm-'
+    assign name_id = form_id | append: '-name'
+    assign email_id = form_id | append: '-email'
+    assign email_error_id = form_id | append: '-email-error'
+    assign phone_id = form_id | append: '-phone'
+    assign body_id = form_id | append: '-body'
+  %}
   {%- form 'contact', id: form_id, class: 'contact-form__form' -%}
     <input
       name="contact[id]"
@@ -33,6 +40,7 @@
 
     {%- if form.errors and form_matches -%}
       <div
+        id="{{ email_error_id }}"
         class="contact-form__error"
         tabindex="-1"
         autofocus
@@ -58,13 +66,13 @@
     <div class="contact-form__form-row">
       <label
         class="visually-hidden"
-        for="ContactForm-name"
+        for="{{ name_id }}"
       >
         {{- 'blocks.contact_form.name' | t -}}
       </label>
       <input
         type="text"
-        id="ContactForm-name"
+        id="{{ name_id }}"
         class="contact-form__input"
         autocomplete="name"
         name="contact[name]"
@@ -74,14 +82,14 @@
 
       <label
         class="visually-hidden"
-        for="ContactForm-email"
+        for="{{ email_id }}"
       >
         {{- 'blocks.contact_form.email' | t -}}
         <span aria-hidden="true">*</span></label
       >
       <input
         type="email"
-        id="ContactForm-email"
+        id="{{ email_id }}"
         class="contact-form__input"
         autocomplete="email"
         name="contact[email]"
@@ -91,7 +99,7 @@
         aria-required="true"
         {% if form.errors contains 'email' and form_matches %}
           aria-invalid="true"
-          aria-describedby="ContactForm-email-error"
+          aria-describedby="{{ email_error_id }}"
         {% endif %}
         placeholder="{{ 'blocks.contact_form.email' | t }}"
       >
@@ -99,13 +107,13 @@
 
     <label
       class="visually-hidden"
-      for="ContactForm-phone"
+      for="{{ phone_id }}"
     >
       {{- 'blocks.contact_form.phone' | t -}}
     </label>
     <input
       type="tel"
-      id="ContactForm-phone"
+      id="{{ phone_id }}"
       class="contact-form__input"
       autocomplete="tel"
       name="contact[phone]"
@@ -116,13 +124,13 @@
 
     <label
       class="visually-hidden"
-      for="ContactForm-body"
+      for="{{ body_id }}"
     >
       {{- 'blocks.contact_form.comment' | t -}}
     </label>
     <textarea
       rows="10"
-      id="ContactForm-body"
+      id="{{ body_id }}"
       class="contact-form__input contact-form__input--textarea"
       name="contact[body]"
       placeholder="{{ 'blocks.contact_form.comment' | t }}"

--- a/blocks/popup-link.liquid
+++ b/blocks/popup-link.liquid
@@ -1,4 +1,7 @@
-{% assign block_settings = block.settings %}
+{% liquid
+  assign block_settings = block.settings
+  assign dialog_heading_id = 'popup-dialog-heading-' | append: block.id
+%}
 
 <script
   src="{{ 'dialog.js' | asset_url }}"
@@ -22,10 +25,10 @@
     ref="dialog"
     class="popup-link__content dialog-modal color-custom-popover{% if block_settings.behavior == 'drawer' %} popup-link__content--drawer dialog-drawer{% endif %}"
     scroll-lock
-    aria-labelledby="popup-dialog-heading"
+    aria-labelledby="{{ dialog_heading_id }}"
   >
     <h2
-      id="popup-dialog-heading"
+      id="{{ dialog_heading_id }}"
       class="visually-hidden"
     >
       {{ block_settings.heading }}

--- a/blocks/review.liquid
+++ b/blocks/review.liquid
@@ -4,6 +4,8 @@
   assign rating = product.metafields.reviews.rating.value.rating
   assign scale_max = product.metafields.reviews.rating.value.scale_max
   assign rating_count = product.metafields.reviews.rating_count
+  assign half_star_id = 'half-' | append: block.id
+  assign star_id = 'star-' | append: block.id
 
   if request.visual_preview_mode and product == blank
     assign product = collections.all.products.first
@@ -55,12 +57,12 @@
       role="presentation"
     >
       <defs>
-        <linearGradient id="half" x1="0" x2="100%" y1="0" y2="0">
+        <linearGradient id="{{ half_star_id }}" x1="0" x2="100%" y1="0" y2="0">
           <stop offset="50%" stop-color="var(--star-fill-color)"></stop>
           <stop offset="50%" stop-color="{% if block_settings.stars_style == "outline" %}transparent{% else %}rgb(var(--star-fill-color-rgb) / var(--opacity-20){% endif %}"></stop>
         </linearGradient>
 
-        <symbol xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" id="star">
+        <symbol xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" id="{{ star_id }}">
           <path d="M31.547 12a.848.848 0 00-.677-.577l-9.427-1.376-4.224-8.532a.847.847 0 00-1.516 0l-4.218 8.534-9.427 1.355a.847.847 0 00-.467 1.467l6.823 6.664-1.612 9.375a.847.847 0 001.23.893l8.428-4.434 8.432 4.432a.847.847 0 001.229-.894l-1.615-9.373 6.822-6.665a.845.845 0 00.214-.869z" />
         </symbol>
       </defs>
@@ -77,7 +79,7 @@
           style="--empty-star-fill-color: rgb(var(--star-fill-color-rgb) / var(--opacity-20))"
           role="presentation"
         >
-          <use xlink:href="#star"></use>
+          <use xlink:href="#{{ star_id }}"></use>
         </svg>
       {% else %}
         {%- for star in (1..star_count_rating) -%}
@@ -87,9 +89,9 @@
             style="--empty-star-fill-color:{% if block_settings.stars_style == 'outline' %}transparent{% else %}rgb(var(--star-fill-color-rgb) / var(--opacity-20)){% endif %}"
             role="presentation"
           >
-            <use xlink:href="#star"{% if decimal_rating == 0.5 and star == svg_filled_stars %} fill="url(#half)"{% endif %}></use>
+            <use xlink:href="#{{ star_id }}"{% if decimal_rating == 0.5 and star == svg_filled_stars %} fill="url(#{{ half_star_id }})"{% endif %}></use>
             {% if block_settings.stars_style == "outline" %}
-              <use xlink:href="#star" fill="none" stroke="var(--star-fill-color)" stroke-width="var(--icon-stroke-width)"></use>
+              <use xlink:href="#{{ star_id }}" fill="none" stroke="var(--star-fill-color)" stroke-width="var(--icon-stroke-width)"></use>
             {% endif %}
           </svg>
         {%- endfor -%}

--- a/snippets/blog-comment-form.liquid
+++ b/snippets/blog-comment-form.liquid
@@ -7,6 +7,12 @@
   @param {string} [section_id] - The section ID
 {%- enddoc -%}
 
+{% liquid
+  assign author_error_id = section_id | append: '-blog-post-comment-author-error'
+  assign email_error_id = section_id | append: '-blog-post-comment-email-error'
+  assign body_error_id = section_id | append: '-blog-post-comment-body-error'
+%}
+
 {% form 'new_comment', article %}
   <div class="blog-post-comments__form-container">
     <h2 class="h3">{{- 'blogs.comment_form.heading' | t -}}</h2>
@@ -25,12 +31,16 @@
         {%- for field in form.errors -%}
           <li>
             {%- if form.errors.translated_fields[field] contains 'author' -%}
-              <span id="blog-post-comment-author-error">
+              <span id="{{ author_error_id }}">
                 {{- 'blogs.comment_form.name' | t -}}
               </span>
             {%- elsif form.errors.translated_fields[field] contains 'body' -%}
-              <span id="blog-post-comment-body-error">
+              <span id="{{ body_error_id }}">
                 {{- 'blogs.comment_form.message' | t -}}
+              </span>
+            {%- elsif form.errors.translated_fields[field] contains 'email' -%}
+              <span id="{{ email_error_id }}">
+                {{- 'blogs.comment_form.email' | t -}}
               </span>
             {%- else -%}
               <span id="{{ form.errors.translated_fields[field] | handleize }}-error">
@@ -80,7 +90,7 @@
           required
           {% if form.errors contains 'author' %}
             aria-invalid="true"
-            aria-describedby="blog-post-comment-author-error"
+            aria-describedby="{{ author_error_id }}"
           {% endif %}
         >
       </div>
@@ -107,7 +117,7 @@
           required
           {% if form.errors contains 'email' %}
             aria-invalid="true"
-            aria-describedby="blog-post-comment-email-error"
+            aria-describedby="{{ email_error_id }}"
           {% endif %}
         >
       </div>
@@ -130,7 +140,7 @@
           required
           {% if form.errors contains 'body' %}
             aria-invalid="true"
-            aria-describedby="blog-post-comment-body-error"
+            aria-describedby="{{ body_error_id }}"
           {% endif %}
         >
           {{- form.body -}}


### PR DESCRIPTION
﻿## What changed

This PR fixes duplicate and missing accessibility-related IDs in repeatable theme blocks and snippets.

- Makes contact form field IDs unique per form instance.
- Adds a concrete email error ID for contact form `aria-describedby`.
- Makes popup link dialog heading IDs unique per block instance.
- Makes review star SVG definition IDs unique per block instance.
- Makes blog comment form error IDs unique and ensures the email field references an existing error element.

## Why

Several repeatable blocks used fixed DOM IDs or referenced IDs that may not exist. When multiple instances render on the same page, this can produce duplicate IDs or broken `aria-labelledby` / `aria-describedby` associations.

## Validation

```bash
shopify theme check
```

Result:

```text
327 files inspected with no offenses found.
```
