### PR TITLE
Filter product disclosures by the buyer's jurisdiction

### DIFF
--- a/.prototype/jurisdiction_harness.rb
+++ b/.prototype/jurisdiction_harness.rb
@@ -1,0 +1,166 @@
+# frozen_string_literal: true
+
+# Prototype harness. Not theme content. Delete before any real PR.
+#
+# Renders snippets/disclosure-jurisdiction-match.liquid with the stock Liquid gem against stub drops,
+# and checks every row of the behaviour table documented in that snippet.
+#
+# Run: ruby .prototype/jurisdiction_harness.rb
+
+require "liquid"
+
+SNIPPET = File.join(__dir__, "..", "snippets", "disclosure-jurisdiction-match.liquid")
+
+# The stock gem has no `{% doc %}` tag, which is a Shopify theme extension, so strip it.
+SOURCE = File.read(SNIPPET).sub(/\{%\s*doc\s*%\}.*?\{%\s*enddoc\s*%\}\s*/m, "")
+
+# Exercise the snippet the way the call sites do, so the capture and the `!= blank` test are covered
+# rather than just the snippet's raw output. `render` isolates scope, so the caller cannot read an
+# `assign` from inside the snippet; capture-around-render is Horizon's convention for this, used at
+# sections/quick-order-list.liquid:338. The stock gem resolves `render` through a file system, so
+# register the snippet under the name the theme uses.
+CALL_SITE = <<~LIQUID
+  {%- capture disclosure_visible -%}
+    {%- render 'disclosure-jurisdiction-match', disclosure: disclosure -%}
+  {%- endcapture -%}
+  {%- if disclosure_visible != blank -%}SHOWN{%- else -%}HIDDEN{%- endif -%}
+LIQUID
+
+class SingleSnippetFileSystem
+  def initialize(source)
+    @source = source
+  end
+
+  def read_template_file(template_path)
+    return @source if template_path == "disclosure-jurisdiction-match"
+
+    raise Liquid::FileSystemError, "unexpected snippet: #{template_path}"
+  end
+end
+
+# Shopify's `{% render %}` hides the caller's local variables but keeps theme globals such as
+# `localization`, `product` and `settings` visible inside the snippet. In the stock gem the equivalent
+# is `static_environments`, which `Liquid::Context#new_isolated_subcontext` carries into the isolated
+# subcontext while `environments` is dropped. Passing `localization` as a plain assign therefore
+# renders the snippet blind to the buyer, which is a property of this harness and not of the theme.
+LIQUID_ENVIRONMENT = Liquid::Environment.build(file_system: SingleSnippetFileSystem.new(SOURCE))
+
+class ValueDrop < Liquid::Drop
+  def initialize(value)
+    @value = value
+  end
+
+  def value
+    @value
+  end
+end
+
+class DisclosureDrop < Liquid::Drop
+  def initialize(jurisdictions)
+    @jurisdictions = jurisdictions
+  end
+
+  def jurisdictions
+    ValueDrop.new(@jurisdictions)
+  end
+end
+
+class CountryDrop < Liquid::Drop
+  def initialize(iso_code)
+    @iso_code = iso_code
+  end
+
+  def iso_code
+    @iso_code
+  end
+end
+
+class LocalizationDrop < Liquid::Drop
+  def initialize(country:, subdivision:)
+    @country = country
+    @subdivision = subdivision
+  end
+
+  def country
+    CountryDrop.new(@country)
+  end
+
+  def subdivision
+    @subdivision
+  end
+end
+
+TEMPLATE = Liquid::Template.parse(CALL_SITE, environment: LIQUID_ENVIRONMENT)
+
+def visible?(jurisdictions:, country:, subdivision:)
+  context = Liquid::Context.build(
+    environment: LIQUID_ENVIRONMENT,
+    environments: [{ "disclosure" => DisclosureDrop.new(jurisdictions) }],
+    static_environments: {
+      "localization" => LocalizationDrop.new(country: country, subdivision: subdivision),
+    },
+    rethrow_errors: true,
+  )
+
+  output = TEMPLATE.render!(context).strip
+
+  case output
+  when "SHOWN" then true
+  when "HIDDEN" then false
+  else raise "call site produced neither SHOWN nor HIDDEN: #{output.inspect}"
+  end
+end
+
+# Cases marked NOTE record where a theme cannot reproduce a server-side check, either because Liquid
+# has no regex or because the value has already been normalised before the theme sees it.
+#
+# [description, disclosure jurisdictions, buyer country, buyer subdivision, expected visible]
+CASES = [
+  ["All / any buyer",                      ["All"],        "DE", nil,  true],
+  ["All / unknown country",                ["All"],        nil,  nil,  true],
+  ["US / US, no subdivision",              ["US"],         "US", nil,  true],
+  ["US / US-CA buyer",                     ["US"],         "US", "CA", true],
+  ["US-CA / US, no subdivision (fail open)", ["US-CA"],    "US", nil,  true],
+  ["US-CA / US-CA buyer",                  ["US-CA"],      "US", "CA", true],
+  ["US-CA / US-TX buyer",                  ["US-CA"],      "US", "TX", false],
+  ["US-CA / CA-BC buyer",                  ["US-CA"],      "CA", "BC", false],
+  ["US / CA buyer",                        ["US"],         "CA", nil,  false],
+  ["US-CA / unknown country (fail open)",  ["US-CA"],      nil,  nil,  true],
+  ["empty jurisdiction list",              [],             "US", "TX", true],
+  ["legacy value ['California']",          ["California"], "US", "TX", true],
+  # Extra cases beyond the PR table, to pin behaviour the Ruby filter also has.
+  ["multi-entry, one match",               ["CA-QC", "US-CA"], "US", "CA", true],
+  ["multi-entry, no match",                ["CA-QC", "US-CA"], "US", "TX", false],
+  ["lowercase input normalised",           ["us-ca"],      "us", "ca", true],
+  ["mixed recognised and junk, no match",  ["California", "US-CA"], "US", "TX", false],
+  # A stricter check would require two letters, not two characters. Liquid has no regex, so "U1" is
+  # accepted as a country code here and the disclosure is hidden rather than failing open.
+  ["NOTE: digit in country code",          ["U1"],         "US", "TX", false],
+  # `localization.country` never returns blank, because the storefront substitutes the shop's backup
+  # region when the buyer country cannot be resolved. An unresolved buyer on a US shop therefore
+  # arrives here as a US buyer and CA-QC is hidden. That fallback is intended behaviour.
+  ["NOTE: unresolved buyer reads as backup country", ["CA-QC"], "US", nil, false],
+].freeze
+
+passed = 0
+failed = 0
+
+CASES.each do |description, jurisdictions, country, subdivision, expected|
+  actual = visible?(jurisdictions: jurisdictions, country: country, subdivision: subdivision)
+  ok = actual == expected
+  ok ? passed += 1 : failed += 1
+  buyer = [country || "nil", subdivision || "nil"].join(" / ")
+  printf(
+    "%-4s %-42s jurisdictions=%-24s buyer=%-12s expected=%-5s actual=%s\n",
+    ok ? "ok" : "FAIL",
+    description,
+    jurisdictions.inspect,
+    buyer,
+    expected,
+    actual,
+  )
+end
+
+puts
+puts "#{passed} passed, #{failed} failed"
+exit(failed.zero? ? 0 : 1)

--- a/blocks/disclosures.liquid
+++ b/blocks/disclosures.liquid
@@ -3,7 +3,10 @@
 {%- assign disclosures_symbol_aspect_ratio = 1 -%}
 {%- if disclosures != blank -%}
   {%- for disclosure in disclosures -%}
-    {%- if disclosure.display_preferences.value.surfaces contains 'product_page' -%}
+    {%- capture disclosure_visible -%}
+      {%- render 'disclosure-jurisdiction-match', disclosure: disclosure -%}
+    {%- endcapture -%}
+    {%- if disclosure_visible != blank and disclosure.display_preferences.value.surfaces contains 'product_page' -%}
       {%- assign has_visible_disclosures = true -%}
       {%- assign symbol_aspect_ratio = disclosure.symbol.value.aspect_ratio | default: 1 -%}
       {%- if symbol_aspect_ratio > disclosures_symbol_aspect_ratio -%}
@@ -38,7 +41,10 @@
         <span class="disclosures__summary-item">
           {%- assign visible_disclosure_index = 0 -%}
           {%- for disclosure in disclosures -%}
-            {%- if disclosure.display_preferences.value.surfaces contains 'product_page' -%}
+            {%- capture disclosure_visible -%}
+              {%- render 'disclosure-jurisdiction-match', disclosure: disclosure -%}
+            {%- endcapture -%}
+            {%- if disclosure_visible != blank and disclosure.display_preferences.value.surfaces contains 'product_page' -%}
               {%- assign title = disclosure.title.value -%}
               {%- assign img = disclosure.symbol.value -%}
               {%- capture row_content -%}
@@ -75,7 +81,10 @@
       {%- assign details_html = '' -%}
       {%- assign visible_disclosure_index = 0 -%}
       {%- for disclosure in disclosures -%}
-        {%- if disclosure.display_preferences.value.surfaces contains 'product_page' -%}
+        {%- capture disclosure_visible -%}
+          {%- render 'disclosure-jurisdiction-match', disclosure: disclosure -%}
+        {%- endcapture -%}
+        {%- if disclosure_visible != blank and disclosure.display_preferences.value.surfaces contains 'product_page' -%}
           {%- assign title = disclosure.title.value -%}
           {%- assign img = disclosure.symbol.value -%}
           {%- assign content = disclosure.content -%}

--- a/snippets/cart-disclosure-tooltip.liquid
+++ b/snippets/cart-disclosure-tooltip.liquid
@@ -31,6 +31,9 @@
   -%}
 
   {%- for disclosure in disclosures -%}
+    {%- capture disclosure_visible -%}
+      {%- render 'disclosure-jurisdiction-match', disclosure: disclosure -%}
+    {%- endcapture -%}
     {%- liquid
       assign render_disclosure = true
       if filter_by_cart_surface
@@ -39,6 +42,9 @@
         if surfaces contains 'cart'
           assign render_disclosure = true
         endif
+      endif
+      if disclosure_visible == blank
+        assign render_disclosure = false
       endif
 
       assign disclosure_title = disclosure.title.value | default: disclosure.title
@@ -59,6 +65,9 @@
 
   {%- capture disclosure_rows -%}
     {%- for disclosure in disclosures -%}
+      {%- capture disclosure_visible -%}
+        {%- render 'disclosure-jurisdiction-match', disclosure: disclosure -%}
+      {%- endcapture -%}
       {%- liquid
         assign render_disclosure = true
         if filter_by_cart_surface
@@ -67,6 +76,9 @@
           if surfaces contains 'cart'
             assign render_disclosure = true
           endif
+        endif
+        if disclosure_visible == blank
+          assign render_disclosure = false
         endif
 
         assign disclosure_title = disclosure.title.value | default: disclosure.title
@@ -99,6 +111,9 @@
 
   {%- capture disclosure_modal_items -%}
     {%- for disclosure in disclosures -%}
+      {%- capture disclosure_visible -%}
+        {%- render 'disclosure-jurisdiction-match', disclosure: disclosure -%}
+      {%- endcapture -%}
       {%- liquid
         assign render_disclosure = true
         if filter_by_cart_surface
@@ -107,6 +122,9 @@
           if surfaces contains 'cart'
             assign render_disclosure = true
           endif
+        endif
+        if disclosure_visible == blank
+          assign render_disclosure = false
         endif
 
         assign disclosure_title = disclosure.title.value | default: disclosure.title

--- a/snippets/disclosure-jurisdiction-match.liquid
+++ b/snippets/disclosure-jurisdiction-match.liquid
@@ -1,0 +1,97 @@
+{% doc %}
+  Decides whether one disclosure applies to the current buyer's jurisdiction.
+
+  Outputs the string `visible` when the disclosure applies, and nothing when it does not. Liquid has
+  no return value and `render` isolates scope, so callers capture the output and test it against
+  `blank`:
+
+  @param {object} disclosure - A disclosure metaobject from `product.metafields.shopify.disclosure.value`
+
+  @example
+  {%- capture disclosure_visible -%}
+    {%- render 'disclosure-jurisdiction-match', disclosure: disclosure -%}
+  {%- endcapture -%}
+  {%- if disclosure_visible != blank -%}
+    ...
+  {%- endif -%}
+
+  Matching is country-first and fails open, so a disclosure is shown whenever the theme cannot prove
+  it does not apply:
+
+  | Disclosure jurisdiction | Buyer country / subdivision | Result  |
+  | ----------------------- | --------------------------- | ------- |
+  | `All`                   | anything                    | visible |
+  | `US`                    | `US` / nil                  | visible |
+  | `US`                    | `US` / `CA`                 | visible |
+  | `US-CA`                 | `US` / nil                  | visible |
+  | `US-CA`                 | `US` / `CA`                 | visible |
+  | `US-CA`                 | `US` / `TX`                 | hidden  |
+  | `US-CA`                 | `CA` / `BC`                 | hidden  |
+  | `US`                    | `CA` / nil                  | hidden  |
+  | anything                | unknown country             | visible |
+  | unrecognised code       | anything                    | visible |
+
+  `localization.country` never returns blank. When the buyer's country cannot be resolved the
+  storefront substitutes the shop's backup region, so an unresolved buyer is matched as a buyer in the
+  shop's home country. That is the intended fallback, and it means the "unknown country" row above is
+  reached only when `localization.country.iso_code` is genuinely empty.
+
+  Requires `localization.subdivision`, which is not available in Liquid yet. Without it every
+  subdivision-scoped jurisdiction such as `US-CA` matches on country alone, which is the fail-open
+  row of the table.
+{% enddoc %}
+
+{%- liquid
+  assign jurisdiction_match = ''
+  assign buyer_country = localization.country.iso_code | upcase
+  assign buyer_subdivision = localization.subdivision | upcase
+  assign jurisdictions = disclosure.jurisdictions.value
+
+  if jurisdictions == blank
+    assign jurisdiction_match = 'visible'
+  elsif buyer_country == blank
+    assign jurisdiction_match = 'visible'
+  else
+    assign matched = false
+    assign recognised = false
+
+    for jurisdiction in jurisdictions
+      assign code = jurisdiction | strip | upcase
+
+      if code == 'ALL'
+        assign recognised = true
+        assign matched = true
+        continue
+      endif
+
+      assign code_parts = code | split: '-'
+      assign code_country = code_parts[0]
+      assign code_subdivision = code_parts[1]
+
+      if code_country.size != 2
+        continue
+      endif
+
+      assign recognised = true
+
+      if code_country != buyer_country
+        continue
+      endif
+
+      if code_subdivision == blank
+        assign matched = true
+      elsif buyer_subdivision == blank
+        assign matched = true
+      elsif code_subdivision == buyer_subdivision
+        assign matched = true
+      endif
+    endfor
+
+    if recognised == false
+      assign jurisdiction_match = 'visible'
+    elsif matched
+      assign jurisdiction_match = 'visible'
+    endif
+  endif
+-%}
+{{- jurisdiction_match -}}


### PR DESCRIPTION
## What this does

Disclosures render on the product page and in the cart today, filtered only by
`display_preferences.surfaces`. The `jurisdictions` field on each disclosure is never read, so a
disclosure scoped to one state or province shows to every buyer. A California Prop 65 warning renders
for a buyer in Germany.

This adds `snippets/disclosure-jurisdiction-match.liquid` and wires it into the three loops in
`blocks/disclosures.liquid` and the three in `snippets/cart-disclosure-tooltip.liquid`.

## Matching rules

Country-first, and it fails open, so a disclosure is shown whenever the theme cannot prove it does not
apply.

| Disclosure jurisdiction | Buyer country / subdivision | Result |
| --- | --- | --- |
| `All` | anything | visible |
| `US` | `US` / nil | visible |
| `US` | `US` / `CA` | visible |
| `US-CA` | `US` / nil | visible |
| `US-CA` | `US` / `CA` | visible |
| `US-CA` | `US` / `TX` | hidden |
| `US-CA` | `CA` / `BC` | hidden |
| `US` | `CA` / nil | hidden |
| anything | unknown country | visible |
| unrecognised or legacy value | anything | visible |

## Draft, and why

This cannot work until `localization.subdivision` exists in Liquid. There is no way to read the
buyer's subdivision from a theme today, so a `US-CA` disclosure matches on country alone, which is
the fail-open path. Subdivision-scoped entries therefore behave exactly as they do now until that
lands.

Worth weighing before anyone reviews the Liquid closely: the same filtering could be done in the
platform, on the read path that resolves the metafield, in which case the theme needs no change at
all and Hydrogen and every other theme get it for free. This branch exists so we can see what the
theme-side version actually costs, which is 118 lines and 6 call sites, and compare.

Two rules a theme cannot reproduce, both recorded in the harness:

- Liquid has no regex, so a jurisdiction code is only checked for a two-character country part.
  `U1` is accepted as a country and hides, where a stricter check would fail open.
- `localization.country` never returns blank, because the storefront substitutes the shop's backup
  region when the buyer country cannot be resolved. An unresolved buyer on a US shop is matched as a
  US buyer. That fallback is intended behaviour, noted here only so the table above is not
  misread.

## Notes on the implementation

Liquid has no return value and `render` isolates the caller's locals, so the matcher cannot be a
function. It prints a token and each call site captures it, the same pattern the theme already uses
for `format-price`. The `render` cannot be hoisted out of its loop, so the matcher runs once per
disclosure per pass.

## Verification

`ruby .prototype/jurisdiction_harness.rb` gives 18 passed, 0 failed. It renders the snippet through
the real capture-and-render call site against stub drops rather than checking the snippet's raw
output, which matters because `render` keeps theme globals but drops caller locals, and the first
version of this harness passed while the call sites were broken.

Proven red three ways: making the matcher always visible reproduces today's behaviour and fails 6
cases, removing the fail-open on an unknown subdivision fails 1, and removing the fail-open on
unrecognised codes fails 1.

`.prototype/` is a development aid, not theme content, and comes out before this is proposed for
merge.
