### PR TITLE
Add missing variable to preview mode defaults

### DIFF
--- a/blocks/review.liquid
+++ b/blocks/review.liquid
@@ -7,7 +7,7 @@
 
   if request.visual_preview_mode and product == blank
     assign product = collections.all.products.first
-    assign rating = product.metafields.reviews.rating.value | default: 4
+    assign rating = product.metafields.reviews.rating.value.rating | default: 4
     assign scale_max = product.metafields.reviews.rating.value.scale_max | default: 5
     assign rating_count = product.metafields.reviews.rating_count | default: 3
   endif


### PR DESCRIPTION
The rating variable was missing the final '.rating' to allow it to appear correctly when previewing a product without review metafields in place.